### PR TITLE
only copy *.epub to target in sphinx:generate

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/SphinxSupport.scala
+++ b/src/main/scala/com/typesafe/sbt/site/SphinxSupport.scala
@@ -92,7 +92,7 @@ object SphinxSupport {
       val cache = cacheDir / "sphinx" / "docs"
       val htmlMapping = htmlOutput.toSeq flatMap { html => (html ***).get x rebase(html, target) }
       val pdfMapping = pdfOutputs map { pdf => (pdf, target / pdf.name) }
-      val epubMapping = epubOutput.toSeq flatMap { epub => (epub ***).get x rebase(epub, target) }
+      val epubMapping = epubOutput.toSeq flatMap { epub => (epub ** "*.epub").get x rebase(epub, target) }
       val mapping = htmlMapping ++ pdfMapping ++ epubMapping
       Sync(cache)(mapping)
       s.log.info("Sphinx documentation generated: %s" format target)


### PR DESCRIPTION
The previously added code tried to copy also the *.html files from the epub target directory into the assembled docs directory, which would fail if html output was also enabled. Instead just grab the *.epub and be done with it.
