### PR TITLE
Updated the asciidoctorj dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "net.databinder" %% "pamflet-library"  % "0.6.0",
   "org.yaml"        % "snakeyaml"        % "1.13",
   "com.typesafe"    % "config"           % "1.2.1", // Last version to support Java 1.6
-  "org.asciidoctor" % "asciidoctorj"     % "1.5.2"
+  "org.asciidoctor" % "asciidoctorj"     % "1.5.4"
 )
 
 scriptedSettings


### PR DESCRIPTION
The dependency to asciidoctorj is now set to 1.5.4.

The releases since the previously used version 1.5.2 contain several bugfixes and improvements.
