### PR TITLE
Add support for Hugo static site generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ install:
   - gem install jekyll:2.5.3 nanoc:3.8.0 asciidoctor --no-rdoc --no-ri
   - npm install -g gitbook-cli
   - |
-    wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz $TRAVIS_BUILD_DIR/hugo.tgz && \
-    tar xvf $TRAVIS_BUILD_DIR/hugo.tgz && \
+    mkdir $TRAVIS_BUILD_DIR/download && \
+    wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
+    tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     sudo mv $TRAVIS_BUILD_DIR/hugo /usr/local/bin/hugo && \
     sudo chmod +x /usr/local/bin/hugo && \
-    rm $TRAVIS_BUILD_DIR/hugo.tgz
+    rm -rf $TRAVIS_BUILD_DIR/download/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - gem install jekyll:2.5.3 nanoc:3.8.0 asciidoctor --no-rdoc --no-ri
   - npm install -g gitbook-cli
   - |
-    mkdir $TRAVIS_BUILD_DIR/download && \
+    mkdir $TRAVIS_BUILD_DIR/download && mkdir $HOME/bin && \
     wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     mv $TRAVIS_BUILD_DIR/hugo $HOME/bin/hugo && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 before_install:
   - rvm install 2.2.3
 
-sudo: false
+sudo: true
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 before_install:
   - rvm install 2.2.3
 
-sudo: true
+sudo: false
 
 addons:
   apt:
@@ -30,6 +30,9 @@ install:
     mkdir $TRAVIS_BUILD_DIR/download && \
     wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
-    sudo mv $TRAVIS_BUILD_DIR/hugo /usr/local/bin/hugo && \
-    sudo chmod +x /usr/local/bin/hugo && \
+    mv $TRAVIS_BUILD_DIR/hugo $HOME/bin/hugo && \
+    chmod +x $HOME/bin/hugo && \
     rm -rf $TRAVIS_BUILD_DIR/download/
+
+before_script:
+  - export PATH=$PATH:$HOME/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,9 @@ before_install:
 install:
   - gem install jekyll:2.5.3 nanoc:3.8.0 asciidoctor --no-rdoc --no-ri
   - npm install -g gitbook-cli
+  - |
+    wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz $TRAVIS_BUILD_DIR/hugo.tgz && \
+    tar xvf $TRAVIS_BUILD_DIR/hugo.tgz && \
+    sudo mv $TRAVIS_BUILD_DIR/hugo /usr/local/bin/hugo && \
+    sudo chmod +x /usr/local/bin/hugo && \
+    rm $TRAVIS_BUILD_DIR/hugo.tgz

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This sbt plugin generates project websites from static content, [Jekyll], [Sphin
 		- [Asciidoctor Site Generation](#asciidoctor-site-generation)
 		- [GitBook Site Generation](#gitbook-site-generation)
 		- [Paradox Site Generation](#paradox-site-generation)
+		- [Hugo Site Generation](#hugo-site-generation)
 	- [ScalaDoc APIs](#scaladoc-apis)
 	- [Previewing the Site](#previewing-the-site)
 	- [Packaging and Publishing](#packaging-and-publishing)
@@ -231,6 +232,26 @@ This assumes you have a Paradox project under the `src/paradox` directory. To ch
 
 ```
 sourceDirectory in Paradox := sourceDirectory.value / "doc"
+```
+
+### Hugo Site Generation
+
+The `sbt-site` plugin has support for building [Hugo](http://gohugo.io/) projects. To enable Hugo site generation, simply enable the associated plugin in your `build.sbt` file:
+
+```
+enablePlugins(HugoPlugin)
+```
+
+The `hugo` binary must be installed on your `$PATH` in order to be accessible to `sbt-site`. In addition, this plugin assumes you have a Hugo project under the `src/hugo` directory. To change this, set the `sourceDirectory` key in the `Hugo` scope:
+
+```
+sourceDirectory in Paradox := sourceDirectory.value / "doc"
+```
+
+You may also change the [base-url](https://gohugo.io/overview/configuration/) that gets passed to the `hugo` command by adjusting the following setting:
+
+```
+baseURL in Hugo := "https://yourdomain.com"
 ```
 
 ## ScalaDoc APIs

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
@@ -1,0 +1,73 @@
+package com.typesafe.sbt.site.hugo
+
+import com.typesafe.sbt.site.SitePlugin.autoImport.siteSubdirName
+import com.typesafe.sbt.site.SitePreviewPlugin.autoImport.previewFixedPort
+import com.typesafe.sbt.site.SitePlugin
+import com.typesafe.sbt.site.util.SiteHelpers
+import sbt._, Keys._
+import java.net.URI
+
+object HugoPlugin extends AutoPlugin {
+  override def requires = SitePlugin
+  override def trigger = noTrigger
+
+  object autoImport {
+    val Hugo = config("hugo")
+    val minimumHugoVersion = settingKey[String]("minimum-hugo-version")
+    val baseURL = settingKey[URI]("base-url")
+    val checkHugoVersion = taskKey[Unit]("check-hugo-version")
+  }
+
+  import autoImport._
+
+  override def projectSettings = hugoSettings(Hugo)
+
+  /** Creates the settings necessary for running hugo in the given configuration. */
+  def hugoSettings(config: Configuration): Seq[Setting[_]] =
+    inConfig(config)(
+      Seq(
+        includeFilter := ("*.html" | "*.png" | "*.js" | "*.css" | "*.gif" | "CNAME"),
+        minimumHugoVersion := "0.15",
+        baseURL := new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(1313)}"),
+        checkHugoVersion := unsafeCheckHugoVersion(minimumHugoVersion.value, streams.value).get,
+        mappings := {
+          val _ = checkHugoVersion.value // sadly relying on effects here, as is the idiom in sbt-site
+          generate(sourceDirectory.value, target.value, includeFilter.value, baseURL.value, streams.value)
+        },
+        siteSubdirName := ""
+      )
+    ) ++
+      SiteHelpers.directorySettings(config) ++
+      SiteHelpers.watchSettings(config) ++
+      SiteHelpers.addMappingsToSiteDir(mappings in config, siteSubdirName in config)
+
+  /** Run hugo via fork. */
+  private[sbt] def generate(
+    src: File,
+    target: File,
+    inc: FileFilter,
+    baseURL: URI,
+    s: TaskStreams): Seq[(File, String)] = {
+    sbt.Process(Seq("hugo", "-d", target.getAbsolutePath, "--baseURL", baseURL.toString), Some(src)) ! s.log match {
+      case 0 => ()
+      case n => sys.error("Could not run hugo binary, error: " + n)
+    }
+    for {
+      (file, name) <- target ** inc --- target pair relativeTo(target)
+    } yield file -> name
+  }
+
+  import scala.util.{Try, Success, Failure}
+
+  def unsafeCheckHugoVersion(minimumVersion: String, s: TaskStreams): Try[Unit] = {
+    s.log.debug("checking for the installed version of hugo...")
+    for {
+      installed <- Try(Seq("hugo", "-", "version").!!)
+      extracted <- Try("""v(\d\.[1]\d)""".r.findFirstMatchIn(installed.trim))
+      _ <- extracted.fold(Failure(new RuntimeException("Hugo is not currently installed!")): Try[Unit]
+                    )(v => if(v.group(1) >= minimumVersion) Success(())
+                           else Failure(new RuntimeException("The current version of Hugo installed is not new enough to build this project.")))
+    } yield ()
+  }
+
+}

--- a/src/sbt-test/hugo/can-use-hugo/build.sbt
+++ b/src/sbt-test/hugo/can-use-hugo/build.sbt
@@ -1,0 +1,13 @@
+name := "test"
+
+enablePlugins(HugoPlugin)
+
+siteSubdirName in Hugo := "thisIsHugo"
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (target in makeSite).value / (siteSubdirName in Hugo).value
+  val index = dest / "index.html"
+  assert(index.exists, s"${index.getAbsolutePath} did not exist")
+  val content = IO.readLines(index)
+  assert(content.exists(_.contains("Knobs")), s"Did not find expected content in:\n${content.mkString("\n")}")
+}

--- a/src/sbt-test/hugo/can-use-hugo/project/plugins.sbt
+++ b/src/sbt-test/hugo/can-use-hugo/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/config.toml
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/config.toml
@@ -1,0 +1,9 @@
+baseurl = "http://localhost:1313/"
+languageCode = "en-us"
+author = "sbt-site"
+copyright = "All rights reserved."
+
+[params]
+  github_host = "github.com"
+  github_repository = "verizon/knobs"
+  project_name = "Knobs"

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/content/01-test.md
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/content/01-test.md
@@ -1,0 +1,15 @@
++++
+layout      = "single"
+title       = "About"
+slug        = "qqqq"
++++
+
+# Hello
+
+These APIs are Scala bindings on top of DataStax Java driver and require <code>native transport</code> support on Cassandra cluster.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce maximus posuere enim, at malesuada lorem sollicitudin vel. Integer id tellus arcu. Donec pretium et velit eget eleifend. Morbi quam sem, maximus sed nulla faucibus, cursus tristique libero. Morbi et diam viverra, venenatis odio imperdiet, laoreet nisi. Nam commodo, neque sit amet ultrices ultricies, ipsum ipsum scelerisque nisl, non aliquam ipsum ante vel lectus. In varius tellus in tincidunt rutrum. Donec nisl mi, ullamcorper at varius at, egestas non quam. Nullam at tortor pulvinar, ullamcorper risus vitae, vehicula nulla. Praesent tempor vel risus a placerat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eleifend odio sem, ac blandit lectus interdum sit amet. Donec commodo leo mi. Vivamus in porttitor enim, sed euismod mauris. Ut in fringilla neque.
+
+Fusce nec leo velit. Maecenas lacinia, sem non convallis fringilla, elit felis accumsan justo, eu hendrerit nisl purus eu nisl. Sed aliquet turpis euismod aliquam malesuada. In cursus, ipsum id aliquet dapibus, leo nisl sollicitudin tortor, eget aliquet justo augue vel nisi. Curabitur ut nunc vel ligula malesuada imperdiet. Suspendisse erat quam, ornare eu metus ut, accumsan placerat ante. Fusce bibendum elit sed erat mattis, ac tristique orci ullamcorper.
+
+Curabitur sollicitudin eget neque quis sagittis. Ut convallis hendrerit mauris, ut accumsan turpis porttitor ac. Nullam fringilla vestibulum ligula, vitae consectetur nibh pharetra ut. Phasellus suscipit blandit lorem, sit amet luctus ante varius vitae. Vestibulum fermentum hendrerit imperdiet. Morbi id nisi in neque facilisis efficitur eu at nibh. Pellentesque commodo risus nec neque laoreet ornare. Duis ac justo non libero laoreet ultrices gravida eu nisi. Nullam convallis ante nec imperdiet consequat. Praesent ut lorem laoreet, ultricies nulla a, interdum nulla. Integer at risus metus. Maecenas hendrerit odio felis, a porttitor urna lobortis eu. Quisque egestas faucibus libero. Suspendisse ac porta quam.

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/content/02-testxx.md
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/content/02-testxx.md
@@ -1,0 +1,9 @@
++++
+layout      = "single"
+title       = "Foo"
+slug        = "eeeee"
++++
+
+# Another
+
+sdf sdf sdf asdfasdfasd fasdf asdfasdasdf

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/index.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+{{ partial "head.html" . }}
+
+<body class="site">
+  <div class="site-wrap">
+
+  {{ partial "header.html" . }}
+
+    <div class="post p2 p-responsive wrap" role="main">
+      <div class="measure">
+        <div class="post">
+          <main role="main">
+            {{ range .Data.Pages }}
+            <a name="{{ .Slug | lower }}"></a>
+            <article class="post-content">
+              {{ .Content }}
+            </article>
+            {{ end }}
+          </main>
+        </div>
+      </div>
+    </div>
+  </div>
+
+{{ partial "footer.html" . }}
+
+</body>
+</html>

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/footer.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/footer.html
@@ -1,0 +1,8 @@
+<footer class="center">
+  <div class="measure">
+    <small>
+      Theme crafted with &lt;3 by <a href="http://johnotander.com">John Otander</a> (<a href="https://twitter.com/4lpine">@4lpine</a>).<br>
+      &lt;/&gt; available on <a href="https://github.com/johnotander/pixyll">Github</a>.
+    </small>
+  </div>
+</footer>

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/head.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/head.html
@@ -1,0 +1,14 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Frida &#8211; frida</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Documentation for frida">
+  <meta name="robots" content="all">
+  <meta name="author" content="Verizon">
+
+  <link rel="canonical" href="https://github.oncue.verizon.net/iptv/frida/pages/iptv/frida/">
+  <link rel="stylesheet" href="/css/pixyll.css" type="text/css">
+  <link href='//fonts.googleapis.com/css?family=Merriweather:900,900italic,300,300italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:900,300' rel='stylesheet' type='text/css'>
+</head>

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/header.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/partials/header.html
@@ -1,0 +1,15 @@
+<header class="site-header px2 px-responsive">
+  <div class="mt2 wrap">
+    <div class="measure">
+      <a href="//{{ $.Param "github_host" }}/{{ $.Param "github_repository" }}" class="site-title">
+      {{ $.Param "project_name" }}
+      </a>
+      <nav class="site-nav">
+        {{ range .Data.Pages }}
+        <a href="#{{ .Slug | lower }}">{{ .Title | lower }}</a>
+        {{ end }}
+      </nav>
+      <div class="clearfix"></div>
+    </div>
+  </div>
+</header>

--- a/src/sbt-test/hugo/can-use-hugo/test
+++ b/src/sbt-test/hugo/can-use-hugo/test
@@ -1,0 +1,2 @@
+> make-site
+> checkContent


### PR DESCRIPTION
This PR adds support for the [Hugo](http://gohugo.io/) static site generator (which we find preferable to Jekyll as its a single, static binary, thus avoiding dependency hell with Ruby gems).
