### PR TITLE
Migrated depreacted usage of / on settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When you run `makeSite`, your project's webpage is generated in the `target/site
 The `src/site` directory can be overridden via the `siteSourceDirectory` key:
 
 ```sbt
-siteSourceDirectory <<= target / "generated-stuff"
+siteSourceDirectory := target.value / "generated-stuff"
 ```
 
 Additional files outside of `siteSourceDirectory` can be added individually via the `siteMappings` key:


### PR DESCRIPTION
Since sbt 0.13.0 `/` on settings is deprecated. This change migrates to the canonical way of using `:=` and `.value`