### PR TITLE
Use default target value for Paradox

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
@@ -25,7 +25,6 @@ object ParadoxSitePlugin extends AutoPlugin {
       ParadoxPlugin.paradoxSettings ++
       List(
         sourceDirectory in paradox := sourceDirectory.value,
-        target in paradox := target.value,
         includeFilter := AllPassFilter,
         mappings := {
           val _ = paradox.value

--- a/src/sbt-test/paradox/can-use-paradox/build.sbt
+++ b/src/sbt-test/paradox/can-use-paradox/build.sbt
@@ -10,5 +10,8 @@ lazy val root = (project in file(".")).
       assert(index.exists, s"${index.getAbsolutePath} did not exist")
       val content = IO.readLines(index)
       assert(content.exists(_.contains("Paradox Testing")), s"Did not find expected content in:\n${content.mkString("\n")}")
+
+      val themeFile = dest / "paradox/theme/page.st"
+      assert(!themeFile.exists, s"$themeFile should not exist [#80]")
     }
   )


### PR DESCRIPTION
The overridden value caused intermediate HTML and theme files to be
placed into the final output directory.

Fixes #80 

---

With this, `sbt makeSite` for typesafehub/ssl-config#51 results in:

```
/opt/ssl-config@paradox > find documentation/target/site
documentation/target/site
documentation/target/site/CertificateGeneration.html
documentation/target/site/CertificateRevocation.html
documentation/target/site/CertificateValidation.html
documentation/target/site/CipherSuites.html
documentation/target/site/code
documentation/target/site/code/genca.sh
documentation/target/site/code/genclient.sh
documentation/target/site/code/genpassword.sh
documentation/target/site/code/genserver.sh
documentation/target/site/code/genserverexp.sh
documentation/target/site/code/gentruststore.sh
documentation/target/site/code/HowsMySSLSpec.scala
documentation/target/site/css
documentation/target/site/css/fonts
documentation/target/site/css/fonts/icons.eot
documentation/target/site/css/fonts/icons.svg
documentation/target/site/css/fonts/icons.ttf
documentation/target/site/css/fonts/icons.woff
documentation/target/site/css/page.css
documentation/target/site/DebuggingSSL.html
documentation/target/site/DefaultContext.html
documentation/target/site/ExampleSSLConfig.html
documentation/target/site/HostnameVerification.html
documentation/target/site/index.html
documentation/target/site/js
documentation/target/site/js/magellan.js
documentation/target/site/js/page.js
documentation/target/site/KeyStores.html
documentation/target/site/lib
documentation/target/site/lib/foundation
documentation/target/site/lib/foundation/dist
documentation/target/site/lib/foundation/dist/foundation.min.css
documentation/target/site/lib/foundation/dist/foundation.min.js
documentation/target/site/lib/jquery
documentation/target/site/lib/jquery/jquery.min.js
documentation/target/site/lib/normalize.css
documentation/target/site/lib/normalize.css/normalize.css
documentation/target/site/lib/prettify
documentation/target/site/lib/prettify/lang-scala.js
documentation/target/site/lib/prettify/prettify.css
documentation/target/site/lib/prettify/prettify.js
documentation/target/site/LooseSSL.html
documentation/target/site/Protocols.html
documentation/target/site/TestingSSL.html
documentation/target/site/WSQuickStart.html
```