### PR TITLE
Use Scaladoc when referring to Scala's documentation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sbt-site
 
 [![Build Status](https://travis-ci.org/sbt/sbt-site.svg)](https://travis-ci.org/sbt/sbt-site)
-[![Join the chat at https://gitter.im/sbt/sbt-site](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sbt/sbt-site?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/sbt/sbt-site](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sbt/sbt-site)
 [ ![Download](https://api.bintray.com/packages/sbt/sbt-plugin-releases/sbt-site/images/download.svg) ](https://bintray.com/sbt/sbt-plugin-releases/sbt-site-imported/_latestVersion)
 
-This sbt plugin generates project websites from static content, [Jekyll], [Sphinx], [Pamflet], [Nanoc], [GitBook], [Paradox], [Hugo] and/or [Asciidoctor], and can optionally include generated ScalaDoc. It is designed to work hand-in-hand with publishing plugins like [sbt-ghpages].
+This sbt plugin generates project websites from static content, [Jekyll], [Sphinx], [Pamflet], [Nanoc], [GitBook], [Paradox], [Hugo] and/or [Asciidoctor], and can optionally include generated Scaladoc. It is designed to work hand-in-hand with publishing plugins like [sbt-ghpages].
 
 ## Documentation
 

--- a/notes/about.markdown
+++ b/notes/about.markdown
@@ -1,1 +1,1 @@
-This sbt plugin generates project websites from static content, Jekyll, Sphinx, Pamflet, Nanoc, GitBook, Paradox, Hugo and/or Asciidoctor, and can optionally include generated ScalaDoc.
+This sbt plugin generates project websites from static content, Jekyll, Sphinx, Pamflet, Nanoc, GitBook, Paradox, Hugo and/or Asciidoctor, and can optionally include generated Scaladoc.

--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -26,13 +26,13 @@ Or if such files should be added in a separate directory via `addMappingsToSiteD
 
 @@ snip[addMappingsToSiteDir](../../sbt-test/site/can-have-custom-mappings/build.sbt) { #addMappingsToSiteDir }
 
-## ScalaDoc APIs
+## Scaladoc APIs
 
-To include ScalaDoc with your site, add the following line to your `build.sbt`:
+To include Scaladoc with your site, add the following line to your `build.sbt`:
 
 @@ snip[enablePlugin](../../sbt-test/site/can-add-scaladoc/build.sbt) { #enablePlugin }
 
-This will default to putting the ScalaDoc under the `latest/api` directory on the website. You can change this with the `siteSubdirName` key in the `SiteScaladoc` scope:
+This will default to putting the Scaladoc under the `latest/api` directory on the website. You can change this with the `siteSubdirName` key in the `SiteScaladoc` scope:
 
 @@ snip[siteSubdirName](../../sbt-test/site/can-add-scaladoc/build.sbt) { #siteSubdirName }
 

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -1,6 +1,6 @@
 # sbt-site
 
-This sbt-site plugin generates project websites from static content as well as @ref:[third-party generators](generators/index.md) and can optionally include generated ScalaDoc. It is designed to work hand-in-hand with publishing plugins like [sbt-ghpages].
+This sbt-site plugin generates project websites from static content as well as @ref:[third-party generators](generators/index.md) and can optionally include generated Scaladoc. It is designed to work hand-in-hand with publishing plugins like [sbt-ghpages].
 
 Before upgrading please consult the @github:[release notes](/notes/). Instructions for upgrading from a version before 1.x.x can be found in the @github[migration guide].
 

--- a/src/sbt-test/site/can-add-scaladoc/build.sbt
+++ b/src/sbt-test/site/can-add-scaladoc/build.sbt
@@ -5,7 +5,7 @@ enablePlugins(SiteScaladocPlugin)
 //#enablePlugin
 
 //#siteSubdirName
-// Puts ScalaDoc output in `target/site/api/latest`
+// Puts Scaladoc output in `target/site/api/latest`
 siteSubdirName in SiteScaladoc := "api/latest"
 //#siteSubdirName
 


### PR DESCRIPTION
According to @SethTisue as pointed out by @som-snytt.