### PR TITLE
Upgrade ParadoxSitePlugin to sbt-paradox 0.2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.asciidoctor" % "asciidoctorj"     % "1.5.4"
 )
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.7")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.9")
 
 enablePlugins(ParadoxSitePlugin)
 sourceDirectory in Paradox := sourceDirectory.value / "main" / "paradox"

--- a/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
@@ -20,11 +20,13 @@ object ParadoxSitePlugin extends AutoPlugin {
   import ParadoxPlugin.autoImport._
   override def projectSettings = paradoxSettings(Paradox)
   def paradoxSettings(config: Configuration): Seq[Setting[_]] =
-    ParadoxPlugin.paradoxGlobalSettings ++
+    ParadoxPlugin.paradoxSettings(config) ++
     inConfig(config)(
-      ParadoxPlugin.paradoxSettings ++
       List(
-        sourceDirectory in paradox := sourceDirectory.value,
+        sourceDirectory in paradox := {
+          val sd = sourceDirectory.value
+          if (sd.toString endsWith "/paradox/paradox") new File(sd.toString dropRight "/paradox".length) else sd
+        },
         includeFilter := AllPassFilter,
         mappings := {
           val _ = paradox.value


### PR DESCRIPTION
sbt-site 1.2.0 is incompatible with sbt-paradox 0.2.9.
Having these both plugins enabled with these versions causes this exception at sbt startup:

```
java.lang.NoSuchMethodError: com.lightbend.paradox.sbt.ParadoxPlugin$.paradoxSettings()Lscala/collection/Seq;
	at com.typesafe.sbt.site.paradox.ParadoxSitePlugin$.paradoxSettings(ParadoxSitePlugin.scala:25)
...
```

This patch fixes the problem.