### PR TITLE
Fix Hugo 0.20 version check issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     mkdir $TRAVIS_BUILD_DIR/download && mkdir $HOME/bin && \
     wget https://github.com/spf13/hugo/releases/download/v0.20/hugo_0.20_linux-64bit.tar.gz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
-    mv $TRAVIS_BUILD_DIR/hugo $HOME/bin/hugo && \
+    mv $TRAVIS_BUILD_DIR/hugo_0.20_linux_amd64/hugo_0.20_linux_amd64 $HOME/bin/hugo && \
     chmod +x $HOME/bin/hugo && \
     rm -rf $TRAVIS_BUILD_DIR/download/
   - git fetch --tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - npm install -g gitbook-cli
   - |
     mkdir $TRAVIS_BUILD_DIR/download && mkdir $HOME/bin && \
-    wget https://github.com/spf13/hugo/releases/download/v0.16/hugo_0.16_linux-64bit.tgz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
+    wget https://github.com/spf13/hugo/releases/download/v0.20/hugo_0.20_linux-64bit.tar.gz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     mv $TRAVIS_BUILD_DIR/hugo $HOME/bin/hugo && \
     chmod +x $HOME/bin/hugo && \

--- a/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
@@ -63,7 +63,7 @@ object HugoPlugin extends AutoPlugin {
     s.log.debug("checking for the installed version of hugo...")
     for {
       installed <- Try(Seq("hugo", "-", "version").!!)
-      extracted <- Try("""v(\d\.[1]\d)""".r.findFirstMatchIn(installed.trim))
+      extracted <- Try("""v(\d\.\d+)\D""".r.findFirstMatchIn(installed.trim))
       _ <- extracted.fold(Failure(new RuntimeException("Hugo is not currently installed!")): Try[Unit]
                     )(v => if(v.group(1) >= minimumVersion) Success(())
                            else Failure(new RuntimeException("The current version of Hugo installed is not new enough to build this project.")))


### PR DESCRIPTION
Hi,

Starting from Hugo 0.20 (current) old regexp used to extract version is broken. I suggest to change version extraction a bit, so it will include all digits up to next non digit symbol. This will fix issue. Probably make sense to fix .travis.yml too to install latest Hugo during testing, but I don't have experience with travis and I haven't touched config file.