### PR TITLE
Fix issues with Hugo 0.20.1 version extraction. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
   - npm install -g gitbook-cli
   - |
     mkdir $TRAVIS_BUILD_DIR/download && mkdir $HOME/bin && \
-    wget https://github.com/spf13/hugo/releases/download/v0.20/hugo_0.20_linux-64bit.tar.gz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
+    wget https://github.com/spf13/hugo/releases/download/v0.20.1/hugo_0.20.1_linux-64bit.tar.gz -O $TRAVIS_BUILD_DIR/download/hugo.tgz && \
     tar xvf $TRAVIS_BUILD_DIR/download/hugo.tgz && \
-    mv $TRAVIS_BUILD_DIR/hugo_0.20_linux_amd64/hugo_0.20_linux_amd64 $HOME/bin/hugo && \
+    mv $TRAVIS_BUILD_DIR/hugo_0.20.1_linux_amd64/hugo_0.20.1_linux_amd64 $HOME/bin/hugo && \
     chmod +x $HOME/bin/hugo && \
     rm -rf $TRAVIS_BUILD_DIR/download/
   - git fetch --tags

--- a/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
@@ -63,7 +63,7 @@ object HugoPlugin extends AutoPlugin {
     s.log.debug("checking for the installed version of hugo...")
     for {
       installed <- Try(Seq("hugo", "-", "version").!!)
-      extracted <- Try("""v(\d\.\d+)\D""".r.findFirstMatchIn(installed.trim))
+      extracted <- Try("""v(\d(\.\d+)+)\D""".r.findFirstMatchIn(installed.trim))
       _ <- extracted.fold(Failure(new RuntimeException("Hugo is not currently installed!")): Try[Unit]
                     )(v => if(v.group(1) >= minimumVersion) Success(())
                            else Failure(new RuntimeException("The current version of Hugo installed is not new enough to build this project.")))


### PR DESCRIPTION
Hi,
previous fix from #96 was not enough. Version extraction should be relaxed even more.
According to https://github.com/spf13/hugo/issues/2832 they use semantic version, so this update should be final fix.