### PR TITLE
Export optional environment variable map for hugo process

### DIFF
--- a/src/main/paradox/generators/hugo.md
+++ b/src/main/paradox/generators/hugo.md
@@ -14,4 +14,8 @@ You may also change the [base-url](https://gohugo.io/overview/configuration/) th
 
 @@ snip[baseURL](../../../sbt-test/hugo/can-use-hugo/build.sbt) { #baseURL }
 
+To export environment variables when forking the `hugo` process, for example to render with Hugo's [getenv function](https://hugodocs.info/functions/getenv/), use:
+
+@@ snip[extraEnv](../../../sbt-test/hugo/can-use-hugo/build.sbt) { #extraEnv }
+
 [Hugo]: http://gohugo.io/

--- a/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/hugo/HugoPlugin.scala
@@ -15,6 +15,7 @@ object HugoPlugin extends AutoPlugin {
     val Hugo = config("hugo")
     val minimumHugoVersion = settingKey[String]("minimum-hugo-version")
     val baseURL = settingKey[URI]("base-url")
+    var extraEnv = taskKey[Map[String, String]]("hugo-env-vars")
     val checkHugoVersion = taskKey[Unit]("check-hugo-version")
   }
 
@@ -29,10 +30,11 @@ object HugoPlugin extends AutoPlugin {
         includeFilter := ("*.html" | "*.png" | "*.js" | "*.css" | "*.gif" | "CNAME"),
         minimumHugoVersion := "0.15",
         baseURL := new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(1313)}"),
+        extraEnv := Map(),
         checkHugoVersion := unsafeCheckHugoVersion(minimumHugoVersion.value, streams.value).get,
         mappings := {
           val _ = checkHugoVersion.value // sadly relying on effects here, as is the idiom in sbt-site
-          generate(sourceDirectory.value, target.value, includeFilter.value, baseURL.value, streams.value)
+          generate(sourceDirectory.value, target.value, includeFilter.value, baseURL.value, extraEnv.value, streams.value)
         },
         siteSubdirName := ""
       )
@@ -47,8 +49,9 @@ object HugoPlugin extends AutoPlugin {
     target: File,
     inc: FileFilter,
     baseURL: URI,
+    envVars: Map[String, String],
     s: TaskStreams): Seq[(File, String)] = {
-    sbt.Process(Seq("hugo", "-d", target.getAbsolutePath, "--baseURL", baseURL.toString), Some(src)) ! s.log match {
+    sbt.Process(Seq("hugo", "-d", target.getAbsolutePath, "--baseURL", baseURL.toString), Some(src), envVars.toSeq: _*) ! s.log match {
       case 0 => ()
       case n => sys.error("Could not run hugo binary, error: " + n)
     }

--- a/src/sbt-test/hugo/can-use-hugo/build.sbt
+++ b/src/sbt-test/hugo/can-use-hugo/build.sbt
@@ -10,10 +10,18 @@ baseURL in Hugo := uri("https://yourdomain.com")
 
 siteSubdirName in Hugo := "thisIsHugo"
 
+//#extraEnv
+extraEnv in Hugo := Map("MY_ENV" -> "Is set!", "MY_OTHER_ENV" -> "Is also set.")
+//#extraEnv
+
 TaskKey[Unit]("checkContent") := {
   val dest = (target in makeSite).value / (siteSubdirName in Hugo).value
   val index = dest / "index.html"
   assert(index.exists, s"${index.getAbsolutePath} did not exist")
   val content = IO.readLines(index)
   assert(content.exists(_.contains("Knobs")), s"Did not find expected content in:\n${content.mkString("\n")}")
+  val myEnvText = "MY_ENV=&quot;Is set!&quot;"
+  assert(content.exists(_.contains(myEnvText)), s"MY_ENV was not rendered in index.html via shortcode. Expected to find: $myEnvText")
+  val myOtherEnvText = "MY_OTHER_ENV=&quot;Is also set.&quot;"
+  assert(content.exists(_.contains(myOtherEnvText)), s"MY_OTHER_ENV was not rendered in index.html via shortcode. Expected to find: $myOtherEnvText")
 }

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/content/03-test-shortcode-from-env.md
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/content/03-test-shortcode-from-env.md
@@ -1,0 +1,15 @@
++++
+layout      = "single"
+title       = "Shortcode Test"
+slug        = "shortcode"
++++
+
+# Shortcode test
+
+Render a [shortcode](https://gohugo.io/extras/shortcodes/) that
+comes from an environment variable:
+
+```
+MY_ENV="{{< MY_ENV >}}"             // <-- comes from layouts/shortcodes/MY_ENV.html
+MY_OTHER_ENV="{{< myOtherEnv >}}"   // <-- comes from layouts/shortcodes/myOtherEnv.html
+```

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/shortcodes/MY_ENV.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/shortcodes/MY_ENV.html
@@ -1,0 +1,1 @@
+{{ getenv "MY_ENV" }}

--- a/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/shortcodes/myOtherEnv.html
+++ b/src/sbt-test/hugo/can-use-hugo/src/hugo/layouts/shortcodes/myOtherEnv.html
@@ -1,0 +1,1 @@
+{{ getenv "MY_OTHER_ENV" }}


### PR DESCRIPTION
Adds support to the Hugo generator for:

    extraEnv in Hugo := Map("MY_ENV" -> "Is set!", "MY_OTHER_ENV" -> "Is also set.")

Intend to use `getenv` + shortcodes[1,2] when generating http4s tuts so dependency versions are pulled straight from `libraryDependencies`.

[1] https://hugodocs.info/functions/getenv/
[2] https://gohugo.io/extras/shortcodes/