### PR TITLE
Bump Paradox to version 0.2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.asciidoctor" % "asciidoctorj"     % "1.5.4"
 )
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.9")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.12")
 
 addSbtPlugin("org.planet42"       % "laika-sbt"           % "0.6.0")
 

--- a/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
@@ -21,12 +21,13 @@ object ParadoxSitePlugin extends AutoPlugin {
   override def projectSettings = paradoxSettings(Paradox)
   def paradoxSettings(config: Configuration): Seq[Setting[_]] =
     ParadoxPlugin.paradoxSettings(config) ++
+    List(
+      // Revert config:sourceDirectory set by paradoxSettings
+      sourceDirectory in config := sourceDirectory.value
+    ) ++
     inConfig(config)(
       List(
-        sourceDirectory in paradox := {
-          val sd = sourceDirectory.value
-          if (sd.toString endsWith "/paradox/paradox") new File(sd.toString dropRight "/paradox".length) else sd
-        },
+        sourceDirectory in paradox := sourceDirectory.value,
         includeFilter := AllPassFilter,
         mappings := {
           val _ = paradox.value

--- a/src/sbt-test/site/plays-nice-with-ghpages/build.sbt
+++ b/src/sbt-test/site/plays-nice-with-ghpages/build.sbt
@@ -2,7 +2,7 @@ name := "site ghpages test"
 
 version := "0.0-ABCD"
 
-ghpages.settings
+enablePlugins(GhpagesPlugin)
 
 git.remoteRepo := "git@github.com:metasim/sbt-site.git"
 

--- a/src/sbt-test/site/plays-nice-with-ghpages/project/plugins.sbt
+++ b/src/sbt-test/site/plays-nice-with-ghpages/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")

--- a/src/sbt-test/site/plays-nice-with-tut/build.sbt
+++ b/src/sbt-test/site/plays-nice-with-tut/build.sbt
@@ -1,9 +1,7 @@
 name := "test"
 
 //#tut
-enablePlugins(ParadoxSitePlugin)
-
-tutSettings
+enablePlugins(ParadoxSitePlugin, TutPlugin)
 sourceDirectory in Paradox := tutTargetDirectory.value
 makeSite := makeSite.dependsOn(tut).value
 //#tut

--- a/src/sbt-test/site/plays-nice-with-tut/project/plugins.sbt
+++ b/src/sbt-test/site/plays-nice-with-tut/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.7")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")


### PR DESCRIPTION
Revert the sourceDirectory setting from paradoxSettings since
SiteHelper.directorySettings manages the default value for sbt-site.

---

@sirthias I believe this is more future proof than the fix from #93 since the Paradox test failed when I bumped the version.