### PR TITLE
Support paradox for sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,25 +62,36 @@ git.remoteRepo := scmInfo.value.get.connection
 scriptedSettings
 
 TaskKey[Unit]("runScriptedTest") := Def.taskDyn {
-  if ((sbtBinaryVersion in pluginCrossBuild).value == "0.13") {
-    Def.task{
-      scripted.toTask("").value
-    }
-  } else {
-    val base = sbtTestDirectory.value
-    val exclude = Seq(
-      base / "laika" * AllPassFilter // https://github.com/planet42/Laika/issues/57
-    )
+  val sbtBinVersion = (sbtBinaryVersion in pluginCrossBuild).value
+  val base = sbtTestDirectory.value
 
-    val allTests = base * AllPassFilter * AllPassFilter filter { _.isDirectory }
-    val tests = allTests --- exclude.reduce(_ +++ _)
-    val args = tests.get.map(Path.relativeTo(base)).flatten.mkString(" ", " ", "")
-    streams.value.log.info("scripted test args = " + args)
-
-    Def.task{
-      scripted.toTask(args).value
-    }
+  def isCompatible(directory: File): Boolean = {
+    val buildProps = new java.util.Properties()
+    IO.load(buildProps, directory / "project" / "build.properties")
+    Option(buildProps.getProperty("sbt.version"))
+      .map { version =>
+        val requiredBinVersion = CrossVersion.binarySbtVersion(version)
+        val compatible = requiredBinVersion == sbtBinVersion
+        if (!compatible) {
+          val testName = directory.relativeTo(base).getOrElse(directory)
+          streams.value.log.warn(s"Skipping $testName since it requires sbt $requiredBinVersion")
+        }
+        compatible
+      }
+      .getOrElse(true)
   }
+
+  val testDirectoryFinder = base * AllPassFilter * AllPassFilter filter { _.isDirectory }
+  val tests = for {
+    test <- testDirectoryFinder.get
+    if isCompatible(test)
+    path <- Path.relativeTo(base)(test)
+  } yield path.replace('\\', '/')
+
+  if (tests.nonEmpty)
+    Def.task(scripted.toTask(tests.mkString(" ", " ", "")).value)
+  else
+    Def.task(streams.value.log.warn("No tests can be run for this sbt version"))
 }.value
 
 scriptedLaunchOpts += "-Dproject.version="+version.value

--- a/build.sbt
+++ b/build.sbt
@@ -69,8 +69,7 @@ TaskKey[Unit]("runScriptedTest") := Def.taskDyn {
   } else {
     val base = sbtTestDirectory.value
     val exclude = Seq(
-      base / "laika" * AllPassFilter, // https://github.com/planet42/Laika/issues/57
-      base / "site" * "plays-nice-with-tut" // tut does not support sbt 1.0
+      base / "laika" * AllPassFilter // https://github.com/planet42/Laika/issues/57
     )
 
     val allTests = base * AllPassFilter * AllPassFilter filter { _.isDirectory }

--- a/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
@@ -32,7 +32,7 @@ object ParadoxSitePlugin extends AutoPlugin {
         mappings := {
           val _ = paradox.value
           val output = (target in paradox).value
-          output ** includeFilter.value --- output pair relativeTo(output)
+          output ** includeFilter.value --- output pair Path.relativeTo(output)
         },
         siteSubdirName := ""
       )

--- a/src/sbt-test/laika/blog-post/project/build.properties
+++ b/src/sbt-test/laika/blog-post/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/sbt-test/laika/minimal/project/build.properties
+++ b/src/sbt-test/laika/minimal/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/build.sbt
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/build.sbt
@@ -1,0 +1,18 @@
+name := "test"
+
+enablePlugins(ParadoxSitePlugin, TutPlugin)
+sourceDirectory in Paradox := tutTargetDirectory.value
+makeSite := makeSite.dependsOn(tut).value
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (target in makeSite).value
+
+  def checkFileContent(file: File, expected: String) = {
+    assert(file.exists, s"${file.getAbsolutePath} did not exist")
+    val actual = IO.readLines(file)
+    assert(actual.exists(_.contains(expected)), s"Did not find $expected in:\n${actual.mkString("\n")}")
+  }
+
+  checkFileContent(dest / "index.html", "Here is how you add numbers")
+  checkFileContent(dest / "test.html", "scala.util.Try")
+}

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/project/build.properties
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/project/plugins.sbt
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/src/main/tut/index.md
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/src/main/tut/index.md
@@ -1,0 +1,15 @@
+# Tutorial
+
+<!-- #tut -->
+Here is how you add numbers:
+
+```tut
+1 + 1
+```
+<!-- #tut -->
+
+@@@ index
+
+ - [test](test.md)
+
+@@@

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/src/main/tut/test.md
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/src/main/tut/test.md
@@ -1,0 +1,5 @@
+# Test
+
+```tut:silent
+import scala.util.Try
+```

--- a/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/test
+++ b/src/sbt-test/site/plays-nice-with-tut-sbt-0.13/test
@@ -1,0 +1,2 @@
+> makeSite
+> checkContent

--- a/src/sbt-test/site/plays-nice-with-tut/project/build.properties
+++ b/src/sbt-test/site/plays-nice-with-tut/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.0-RC2

--- a/src/sbt-test/site/plays-nice-with-tut/project/plugins.sbt
+++ b/src/sbt-test/site/plays-nice-with-tut/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.1")


### PR DESCRIPTION
With https://github.com/lightbend/paradox/pull/147 merged and released in paradox version 0.3.0 the `ParadoxSitePlugin` can now be cross compiled for sbt 1.0 version.