### PR TITLE
Build with sbt version 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ script:
 
 sudo: false
 dist: trusty
+jdk: oraclejdk8
 matrix:
   include:
-  - jdk: openjdk7
-    env: SBT_CROSS_VERSION="0.13.16"
-  - jdk: oraclejdk8
-    env: SBT_CROSS_VERSION="1.0.2"
+  - env: SBT_CROSS_VERSION="0.13.16"
+  - env: SBT_CROSS_VERSION="1.0.2"
 
 addons:
   apt:

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import scala.sys.process._
 
 sbtPlugin := true
 
@@ -59,8 +60,6 @@ version in Paradox := {
 enablePlugins(GhpagesPlugin)
 git.remoteRepo := scmInfo.value.get.connection
 //#ghpages-publish
-
-scriptedSettings
 
 TaskKey[Unit]("runScriptedTest") := Def.taskDyn {
   val sbtBinVersion = (sbtBinaryVersion in pluginCrossBuild).value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
 //#sbt-ghpages
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 //#sbt-ghpages
 
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -7,9 +7,8 @@ Before upgrading please consult the @github:[release notes](/notes/). Instructio
 @@@ note
 
 * Version 1.3.0 is cross published to both sbt 0.13 and sbt 1.x, however, the
-  [Laika](generators/laika.md) and [Paradox](generators/paradox.md) generators
-  are only available for sbt 0.13.
-* As of sbt-site version 1.x.x, sbt version >= 0.13.5 is required.
+  [Laika](generators/laika.md) generator is currently only available for sbt 0.13.
+* As of sbt-site version 1.x.x, sbt version 0.13.10+ or 1.0.0-RC2+ is required.
 * For earlier 0.13.x releases, use [version 0.8.2][0.8.2].
 * For sbt 0.12, use [version 0.7.2][0.7.2].
 

--- a/src/sbt-test/site/minimum-sbt-0.13/build.sbt
+++ b/src/sbt-test/site/minimum-sbt-0.13/build.sbt
@@ -1,0 +1,16 @@
+name := "test"
+
+enablePlugins(ParadoxSitePlugin)
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (target in makeSite).value
+
+  def checkFileContent(file: File, expected: String) = {
+    assert(file.exists, s"${file.getAbsolutePath} did not exist")
+    val actual = IO.readLines(file)
+    assert(actual.exists(_.contains(expected)), s"Did not find $expected in:\n${actual.mkString("\n")}")
+  }
+
+  checkFileContent(dest / "index.html", "Add the following dependency to your project:")
+  checkFileContent(dest / "test.html", "scala.util.Try")
+}

--- a/src/sbt-test/site/minimum-sbt-0.13/project/build.properties
+++ b/src/sbt-test/site/minimum-sbt-0.13/project/build.properties
@@ -1,0 +1,2 @@
+# When updating also change the minimum version noted in src/main/paradox/index.md
+sbt.version=0.13.10

--- a/src/sbt-test/site/minimum-sbt-0.13/project/plugins.sbt
+++ b/src/sbt-test/site/minimum-sbt-0.13/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))

--- a/src/sbt-test/site/minimum-sbt-0.13/src/paradox/index.md
+++ b/src/sbt-test/site/minimum-sbt-0.13/src/paradox/index.md
@@ -1,0 +1,15 @@
+# Tutorial
+
+Add the following dependency to your project:
+
+@@dependency [sbt,Gradle,Maven] {
+  group="com.example"
+  artifact="core"
+  version="$project.version$"
+}
+
+@@@ index
+
+ - [test](test.md)
+
+@@@

--- a/src/sbt-test/site/minimum-sbt-0.13/src/paradox/test.md
+++ b/src/sbt-test/site/minimum-sbt-0.13/src/paradox/test.md
@@ -1,0 +1,7 @@
+# Test
+
+To test include the following import.
+
+```scala
+import scala.util.Try
+```

--- a/src/sbt-test/site/minimum-sbt-0.13/test
+++ b/src/sbt-test/site/minimum-sbt-0.13/test
@@ -1,0 +1,2 @@
+> makeSite
+> checkContent

--- a/src/sbt-test/site/minimum-sbt-1.0/build.sbt
+++ b/src/sbt-test/site/minimum-sbt-1.0/build.sbt
@@ -1,0 +1,16 @@
+name := "test"
+
+enablePlugins(ParadoxSitePlugin)
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (target in makeSite).value
+
+  def checkFileContent(file: File, expected: String) = {
+    assert(file.exists, s"${file.getAbsolutePath} did not exist")
+    val actual = IO.readLines(file)
+    assert(actual.exists(_.contains(expected)), s"Did not find $expected in:\n${actual.mkString("\n")}")
+  }
+
+  checkFileContent(dest / "index.html", "Add the following dependency to your project:")
+  checkFileContent(dest / "test.html", "scala.util.Try")
+}

--- a/src/sbt-test/site/minimum-sbt-1.0/project/build.properties
+++ b/src/sbt-test/site/minimum-sbt-1.0/project/build.properties
@@ -1,0 +1,2 @@
+# When updating also change the minimum version noted in src/main/paradox/index.md
+sbt.version=1.0.0-RC2

--- a/src/sbt-test/site/minimum-sbt-1.0/project/plugins.sbt
+++ b/src/sbt-test/site/minimum-sbt-1.0/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))

--- a/src/sbt-test/site/minimum-sbt-1.0/src/paradox/index.md
+++ b/src/sbt-test/site/minimum-sbt-1.0/src/paradox/index.md
@@ -1,0 +1,15 @@
+# Tutorial
+
+Add the following dependency to your project:
+
+@@dependency [sbt,Gradle,Maven] {
+  group="com.example"
+  artifact="core"
+  version="$project.version$"
+}
+
+@@@ index
+
+ - [test](test.md)
+
+@@@

--- a/src/sbt-test/site/minimum-sbt-1.0/src/paradox/test.md
+++ b/src/sbt-test/site/minimum-sbt-1.0/src/paradox/test.md
@@ -1,0 +1,7 @@
+# Test
+
+To test include the following import.
+
+```scala
+import scala.util.Try
+```

--- a/src/sbt-test/site/minimum-sbt-1.0/test
+++ b/src/sbt-test/site/minimum-sbt-1.0/test
@@ -1,0 +1,2 @@
+> makeSite
+> checkContent


### PR DESCRIPTION
Also adds to tests to track the minimum required version of sbt 0.13 and 1.0. For 0.13 we require 0.13.10 since 0.13.9 fails with:

```
[info] java.lang.NoClassDefFoundError: sbt/TrackLevel
[info] 	at java.lang.Class.forName0(Native Method)
[info] 	at java.lang.Class.forName(Class.java:348)
[info] 	at sbt.ModuleUtilities$.getObject(ModuleUtilities.scala:14)
[info] 	at sbt.ModuleUtilities$.getCheckedObject(ModuleUtilities.scala:20)
[info] 	at sbt.ModuleUtilities$$anonfun$getCheckedObjects$1.apply(ModuleUtilities.scala:23)
[info] 	at sbt.ModuleUtilities$$anonfun$getCheckedObjects$1.apply(ModuleUtilities.scala:23)
[info] 	at scala.collection.immutable.Stream$$anonfun$map$1.apply(Stream.scala:376)
[info] 	at scala.collection.immutable.Stream$$anonfun$map$1.apply(Stream.scala:376)
[info] 	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1085)
[info] 	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1077)
[info] 	at scala.collection.immutable.Stream.foreach(Stream.scala:548)
[info] 	at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48)
[info] 	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:176)
[info] 	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:45)
[info] 	at scala.collection.TraversableLike$class.to(TraversableLike.scala:629)
[info] 	at scala.collection.AbstractTraversable.to(Traversable.scala:105)
[info] 	at scala.collection.TraversableOnce$class.toList(TraversableOnce.scala:257)
[info] 	at scala.collection.AbstractTraversable.toList(Traversable.scala:105)
[info] 	at scala.collection.immutable.List.$plus$plus(List.scala:193)
[info] 	at sbt.PluginDiscovery$.discoverAll(PluginDiscovery.scala:38)
```