### PR TITLE
Add SVG and XML to JekyllPlugin's includeFilter

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/jekyll/JekyllPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/jekyll/JekyllPlugin.scala
@@ -25,7 +25,7 @@ object JekyllPlugin extends AutoPlugin {
       Seq(
         checkGems := RubyHelpers.checkGems(requiredGems.value, streams.value),
         requiredGems := Map.empty,
-        includeFilter := ("*.html" | "*.png" | "*.js" | "*.css" | "*.gif" | "CNAME" | ".nojekyll"),
+        includeFilter := ("*.html" | "*.png" | "*.js" | "*.css" | "*.gif" | "*.svg" | "*.xml" | "CNAME" | ".nojekyll"),
         mappings := {
           val _ = checkGems.value
           generate(sourceDirectory.value, target.value, includeFilter.value, streams.value)


### PR DESCRIPTION
The default Jekyll's theme, Minima, contains an SVG file with social icons [1] and generates an XML file for RSS feed [2]. Without SVG and XML in JekyllPlugin's includeFilter, the links to these files are broken.

[1] https://github.com/jekyll/minima/blob/v2.5.0/assets/minima-social-icons.svg
[2] https://github.com/jekyll/minima/blob/v2.5.0/_layouts/home.html#L31