### PR TITLE
Do not revert derived sourceDirectory

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/paradox/ParadoxSitePlugin.scala
@@ -27,7 +27,6 @@ object ParadoxSitePlugin extends AutoPlugin {
     ) ++
     inConfig(config)(
       List(
-        sourceDirectory in paradox := sourceDirectory.value,
         includeFilter := AllPassFilter,
         mappings := {
           val _ = paradox.value
@@ -37,7 +36,7 @@ object ParadoxSitePlugin extends AutoPlugin {
         siteSubdirName := ""
       )
     ) ++
-    SiteHelpers.directorySettings(config) ++
+    SiteHelpers.targetSettings(config) ++
     SiteHelpers.watchSettings(config) ++
     SiteHelpers.addMappingsToSiteDir(mappings in config, siteSubdirName in config)
 }

--- a/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
+++ b/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
@@ -40,6 +40,11 @@ object SiteHelpers {
     inConfig(config)(
       Seq(
         sourceDirectory := sourceDirectory.value / config.name,
+      )) ++ targetSettings(config)
+
+  def targetSettings(config: Configuration): Seq[Setting[_]] =
+    inConfig(config)(
+      Seq(
         target := target.value / config.name
       ))
 

--- a/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
+++ b/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
@@ -39,7 +39,7 @@ object SiteHelpers {
   def directorySettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(
       Seq(
-        sourceDirectory := sourceDirectory.value / config.name,
+        sourceDirectory := sourceDirectory.value / config.name
       )) ++ targetSettings(config)
 
   def targetSettings(config: Configuration): Seq[Setting[_]] =


### PR DESCRIPTION
In the Alpakka project we noticed that `Paradox/paradoxTheme/sourceDirectory` was wrong (contained `paradox/paradox/`) even if `Paradox/paradox/sourceDirectory` was okay when using this plugin.

This PR changes the `ParadoxSitePlugin` only revert the `sourceDirectory` setting without task scope and let Paradox plugin use that value. This makes sure that the reverted value is used under `paradox` and `paradoxTheme` task scopes.