### PR TITLE
 Paradox 0.3.2 -> 0.5.3;  sbt 0.13.17 -> 0.13.18 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ dist: trusty
 jdk: oraclejdk8
 matrix:
   include:
-  - env: SBT_CROSS_VERSION="0.13.17"
+  - env: SBT_CROSS_VERSION="0.13.18"
   - env: SBT_CROSS_VERSION="1.1.6"
 
 addons:

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.asciidoctor" % "asciidoctorj-diagram" % "1.5.4.1"
 )
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.3.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.5.3")
 
 libraryDependencies ++= {
   if ((sbtBinaryVersion in pluginCrossBuild).value == "0.13") {


### PR DESCRIPTION
With the large bump of Paradox I suggest a non-patch release when this is merged.

Paradox [dropped sbt 0.13 support in 0.5.4](https://github.com/lightbend/paradox/milestone/18?closed=1)