### PR TITLE
Add setting for path in preview

### DIFF
--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -55,6 +55,12 @@ To disable browser auto-open, use the key `previewLaunchBrowser`:
 previewLaunchBrowser := false
 ```
 
+In case the page to start preview from isn't the site root, sett `previewPath` to the desired path: 
+
+```sbt
+previewPath := "docs/index.html"
+```
+
 ## Packaging and Publishing
 
 To create a zip package of the site run `package-site`.

--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -55,7 +55,7 @@ To disable browser auto-open, use the key `previewLaunchBrowser`:
 previewLaunchBrowser := false
 ```
 
-In case the page to start preview from isn't the site root, sett `previewPath` to the desired path: 
+In case the page to start preview from isn't the site root, set `previewPath` to the desired path: 
 
 ```sbt
 previewPath := "docs/index.html"

--- a/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
@@ -48,9 +48,8 @@ object SitePreviewPlugin extends AutoPlugin {
 
       Preview(port, (target in previewAuto).value, makeSite, Compat.genSources, state.value) run { server =>
         if (browser)
-          Browser open(server.portBindings.head.url)
           Browser open(server.portBindings.head.url + "/" + path)
-     }
+      }
     },
     previewFixedPort := Some(4000),
     previewLaunchBrowser := true,

--- a/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
@@ -13,6 +13,7 @@ object SitePreviewPlugin extends AutoPlugin {
     val previewAuto = TaskKey[Unit]("previewAuto", "Launches an automatic jetty server that serves your generated site from the target directory")
     val previewFixedPort = SettingKey[Option[Int]]("previewFixedPort") in previewSite
     val previewLaunchBrowser = SettingKey[Boolean]("previewLaunchBrowser") in previewSite
+    val previewPath = SettingKey[String]("previewPath", "path to open on `previewSite` and `previewAuto`") in previewSite
   }
   import SitePlugin.autoImport._
   import autoImport._
@@ -22,6 +23,7 @@ object SitePreviewPlugin extends AutoPlugin {
       val file = makeSite.value
       val portOption = previewFixedPort.value
       val browser = previewLaunchBrowser.value
+      val path = previewPath.value
 
       val port = portOption getOrElse Port.any
       val server = createServer(file, port) start()
@@ -34,7 +36,7 @@ object SitePreviewPlugin extends AutoPlugin {
           waitForKey()
       }
       if(browser)
-        Browser open ("http://localhost:%d/" format port)
+        Browser open ("http://localhost:%d/%s".format(port, path))
       waitForKey()
       server stop()
       server destroy()
@@ -42,14 +44,17 @@ object SitePreviewPlugin extends AutoPlugin {
     previewAuto := {
       val port = previewFixedPort.value getOrElse Port.any
       val browser = previewLaunchBrowser.value
+      val path = previewPath.value
 
       Preview(port, (target in previewAuto).value, makeSite, Compat.genSources, state.value) run { server =>
         if (browser)
           Browser open(server.portBindings.head.url)
-      }
+          Browser open(server.portBindings.head.url + "/" + path)
+     }
     },
     previewFixedPort := Some(4000),
     previewLaunchBrowser := true,
+    previewPath := "",
     target in previewAuto := siteDirectory.value
   )
 


### PR DESCRIPTION
This implements #142 by adding `previewPath` which gets added to the URL opened by `previewSite` and `previewAuto`.
