### PR TITLE
Expose Sphinx option to treat warnings as errors

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/sphinx/SphinxKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/site/sphinx/SphinxKeys.scala
@@ -16,6 +16,8 @@ trait SphinxKeys {
       "sphinx-properties", "-D options that should be passed when running Sphinx.")
   val sphinxIncremental = SettingKey[Boolean](
       "sphinx-incremental", "Use incremental Sphinx building. Off by default.")
+  val sphinxWarningIsError = SettingKey[Boolean](
+      "sphinx-warningiserror", "Treat warnings as errors. Off by default.")
   val sphinxInputs = TaskKey[SphinxInputs](
       "sphinx-inputs", "Combined inputs for the Sphinx runner.")
   val sphinxRunner = TaskKey[SphinxRunner](

--- a/src/main/scala/com/typesafe/sbt/site/sphinx/SphinxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/sphinx/SphinxPlugin.scala
@@ -25,6 +25,7 @@ object SphinxPlugin extends AutoPlugin {
         sphinxProperties := Map.empty,
         sphinxEnv := Map.empty,
         sphinxIncremental := false,
+        sphinxWarningIsError := false,
         includeFilter in generate := AllPassFilter,
         excludeFilter in generate := HiddenFileFilter,
         sphinxInputs := combineSphinxInputs.value,
@@ -78,6 +79,7 @@ object SphinxPlugin extends AutoPlugin {
       (includeFilter in generate).value,
       (excludeFilter in generate).value,
       sphinxIncremental.value,
+      sphinxWarningIsError.value,
       sphinxTags.value,
       sphinxProperties.value,
       sphinxEnv.value


### PR DESCRIPTION
`sphinx-build -W` turns warnings into errors, but this option is not currently exposed by `sbt-site`.