### PR TITLE
Add Asciidoctor attribute support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ libraryDependencies ++= Seq(
   "org.foundweekends" %% "pamflet-library" % "0.8.0",
   "org.yaml"        % "snakeyaml"        % "1.24",
   "com.typesafe"    % "config"           % "1.3.4",
-  "org.asciidoctor" % "asciidoctorj"     % "1.6.2",
-  "org.asciidoctor" % "asciidoctorj-diagram" % "1.5.16"
+  "org.asciidoctor" % "asciidoctorj"     % "2.1.0",
+  "org.asciidoctor" % "asciidoctorj-diagram" % "1.5.18"
 )
 
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.5.5")

--- a/src/main/paradox/generators/asciidoctor.md
+++ b/src/main/paradox/generators/asciidoctor.md
@@ -14,4 +14,17 @@ Similarly, the output can be redirected to a subdirectory of `target/site` via t
 
 @@ snip[siteSubdirName](/src/sbt-test/asciidoctor/can-use-asciidoctor/build.sbt) { #siteSubdirName }
 
+## Attributes
+
+Asciidoctor allows the rendering of documents to be inflenced by [attributes](https://asciidoctor.org/docs/user-manual/#attributes).
+
+You can configure attributes by setting `asciidoctorAttributes`.
+
+```sbt
+asciidoctorAttributes := Map(
+  "skip-front-matter" -> "", // attribute without value can be set to empty string
+  "lang" -> "nl" // attribute with value
+)
+```
+
 [Asciidoctor]: http://asciidoctor.org

--- a/src/main/scala/com/typesafe/sbt/site/asciidoctor/AsciidoctorKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/site/asciidoctor/AsciidoctorKeys.scala
@@ -1,0 +1,10 @@
+package com.typesafe.sbt.site.asciidoctor
+
+import sbt.SettingKey
+
+trait AsciidoctorKeys {
+  val asciidoctorAttributes = SettingKey[Map[String, String]](
+    "asciidoctor-attributes",
+    "Asciidoctor allows the rendering process to be influenced by so-called attributes. " +
+        "You can read more about attributes here: https://asciidoctor.org/docs/user-manual/#attributes")
+}

--- a/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/build.sbt
+++ b/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/build.sbt
@@ -1,0 +1,23 @@
+name := "test"
+
+//#enablePlugin
+enablePlugins(AsciidoctorPlugin)
+//#enablePlugin
+
+//#siteSubdirName
+// Puts output in `target/site/asciimd`
+siteSubdirName in Asciidoctor := "asciimd"
+asciidoctorAttributes in Asciidoctor := Map(
+  "skip-front-matter" -> "", // skip-front-matter is a flag that just has to be present.
+  "lang" -> "nl")
+//#siteSubdirName
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (target in makeSite).value / (siteSubdirName in Asciidoctor).value
+  val index = dest / "index.html"
+  assert(index.exists, s"${index.getAbsolutePath} did not exist")
+  val content = IO.readLines(index)
+
+  assert(content.exists(_.contains("lang=\"nl\"")), s"Did not find expected content in:\n${content.mkString("\n")}")
+  assert(content.forall(!_.contains("title: \"Document Title\"")), s"Expected front-matter metadata to be removed from the output in:\n${content.mkString("\n")}")
+}

--- a/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/project/plugins.sbt
+++ b/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % sys.props("project.version"))

--- a/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/src/asciidoctor/index.adoc
+++ b/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/src/asciidoctor/index.adoc
@@ -1,0 +1,11 @@
+---
+title: "Document Title"
+---
+
+== Hello, AsciiDoc!
+Doc Writer <doc@example.com>
+:project-version:
+
+This tests should show that `attributes` are taken into account while rendering.
+
+This is passed from the sbt build: {project-version}

--- a/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/test
+++ b/src/sbt-test/asciidoctor/asciidoctor-skips-frontmatter/test
@@ -1,0 +1,2 @@
+> makeSite
+> checkContent


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-site/issues/156

Allows users to configure `attributes` for Asciidoctor. They are described here: https://asciidoctor.org/docs/user-manual/#attributes