### PR TITLE
Add release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+## Releasing sbt-site
+
+Releasing requires access to sbt's Bintray and GitHub pages.
+
+1. use the GitHub release draft to create a new release https://github.com/sbt/sbt-site/releases
+1. pull the tag to your local repository and **make sure it is clean**
+1. publish the new version to https://bintray.com/sbt/sbt-plugin-releases/sbt-site with `sbt publish`
+1. use the Bintray UI and publish the uploaded version
+1. update the documentation with `sbt ghpagesPushSite`


### PR DESCRIPTION
(I wonder if the automated deploy to ghpages still works now that it migrated to travis.com. It failed when I released 1.4.1)