### PR TITLE
Scope makeSite task to current project

### DIFF
--- a/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/site/SitePreviewPlugin.scala
@@ -44,7 +44,7 @@ object SitePreviewPlugin extends AutoPlugin {
       val browser = previewLaunchBrowser.value
       val path = previewPath.value
 
-      Preview(port, (target in previewAuto).value, makeSite, Compat.genSources, state.value).run { server =>
+      Preview(port, (target in previewAuto).value, (thisProjectRef.value / makeSite), Compat.genSources, state.value).run { server =>
         if (browser)
           Browser.open(server.portBindings.head.url + "/" + path)
       }


### PR DESCRIPTION
I think this should fix #68.

`com.typesafe.sbt.site.Preview#runTask` is using `sbt.Extracted#runTask` which says "If the project axis is not defined for the key, it is resolved to be the current project." It seems "current project" is ending up as root so it must mean the current project in terms of the one you have selected in `sbt` which would explain why in #158 switching projects avoids the issue.