### PR TITLE
ci: all permissions on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
       - release-*
     tags: ["v*"]
 
-permissions:
-  contents: read
-
 jobs:
   release:
     name: Release to Sonatype
@@ -39,8 +36,6 @@ jobs:
     name: Release Documentation
     if: github.repository == 'sbt/sbt-site'
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
I'm not sure which permissions sbt-ghpages requires to put to the gh-pages branch. 

`contents: write` is not enough to clone?
```
[info] set current project to sbt-site (in build file:/home/runner/work/sbt-site/sbt-site/)
[error] Cloning into '.'...
[error] git@github.com: Permission denied (publickey).
[error] fatal: Could not read from remote repository.
```