### PR TITLE
Use sbt-site-paradox 1.5.0-RC2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-site" % "1.5.0-RC1")
+addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0-RC2")
 //#sbt-ghpages
 addSbtPlugin(
   ("com.github.sbt" % "sbt-ghpages" % "0.7.0")


### PR DESCRIPTION
Dogfood the new smaller sbt plugin for building the sbt-site docs with Paradox.