### PR TITLE
Update unfiltered to 0.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ val commonSettings = Seq(
   )
 )
 
-val unfilteredVersion = "0.10.4"
+val unfilteredVersion = "0.12.0"
 
 lazy val root = project
   .in(file("."))


### PR DESCRIPTION
Loading  `sbt-site`  in recent sbt ecosystem fails with
```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error]         * org.scala-lang.modules:scala-xml_2.12:2.2.0 (early-semver) is selected over 1.3.0
[error]             +- org.scoverage:scalac-scoverage-reporter_2.12:2.1.0 (depends on 2.2.0)
[error]             +- ws.unfiltered:unfiltered_2.12:0.10.4               (depends on 1.3.0)
```
Most of new sbt plugins expect to run with `scala-xml` v2 but `sbt-site` transitively pulls v1.

Update `unfiltered` to newer version, depending on `scala-xml` v2

```
sbt:sbt-site> whatDependsOn org.scala-lang.modules scala-xml_2.12
[info] org.scala-lang.modules:scala-xml_2.12:2.1.0 [S]
[info]   +-ws.unfiltered:unfiltered_2.12:0.12.0 [S]
[info]     +-ws.unfiltered:unfiltered-directives_2.12:0.12.0 [S]
[info]     | +-com.github.sbt:sbt-site:1.6.0+1-9ff99472+20240325-1004-SNAPSHOT
[info]     | 
[info]     +-ws.unfiltered:unfiltered-filter_2.12:0.12.0 [S]
[info]       +-com.github.sbt:sbt-site:1.6.0+1-9ff99472+20240325-1004-SNAPSHOT
```