### PR TITLE
fix: Fixes can-package-and-publish-zip-file

### DIFF
--- a/core/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
+++ b/core/src/main/scala/com/typesafe/sbt/site/util/SiteHelpers.scala
@@ -34,7 +34,8 @@ object SiteHelpers {
 
   def createSiteZip(siteDir: File, zipPath: PluginCompat.ArtifactPath, s: TaskStreams)(implicit conv: xsbti.FileConverter): PluginCompat.FileRef = {
     val zipFile = PluginCompat.artifactPathToFile(zipPath)
-    IO.zip(Path.allSubpaths(siteDir), zipFile, Some(System.currentTimeMillis()))
+    val midnight = (System.currentTimeMillis() / 86400000) * 86400000
+    IO.zip(Path.allSubpaths(siteDir), zipFile, Some(midnight))
     s.log.info("Site packaged: " + zipFile)
     PluginCompat.toFileRef(zipFile)
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-site/issues/232

## Problem
can-package-and-publish-zip-file runs publish and packageSite one after the other, but byte-to-byte comparison frequently fails when it takes longer than 1ms.

## Solution
This rounds down the timestamp to midnight.
